### PR TITLE
Check if the package is in the mapping hash before trying to update it

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -102,7 +102,7 @@ static void cve_add_package_internal(struct source_package_t *pkg)
                 return;
         }
 
-        if (self->mapping) {
+        if (self->mapping && g_hash_table_contains(self->mapping, pkg->name)) {
                 q = g_hash_table_lookup(self->mapping, pkg->name);
 
                 /*


### PR DESCRIPTION
Hello!

When working with a list of faux packages and using a mapping file, I found that unless every package has a corresponding mapping entry, I get a segfault.

**packages.csv:**
```
linux,3.14-myversion,,
bash,4.3.30,,
```

**mapping:**
```
[Mapping]
linux_kernel,3.14 = linux
```

**Result:**
```
bash-4.3# cve-check-tool -M mapping packages.csv 

(cve-check-tool:7): GLib-CRITICAL **: g_strsplit: assertion 'string != NULL' failed
Segmentation fault (core dumped)
```
As long as I add `bash` to the mapping file in any way (like `bash=bash` or `foo,3.5=bash`), it works as expected.  I could reproduce this as far back as 13ec561b78ca9c4ff18a69c1f96aa9aff869cab0.

The code makes sure there is a mapping hash but not whether the package is a key in it, so the NULL returned by the lookup is passed to g_strsplit().

I thought `g_hash_table_contains()` makes sense here since the table and the loop are still using the glib functions, but I also realize you wanted to get away from glib in general, so I could alternatively wrap the stuff in that block with a check that q isn't NULL first if that's preferable..