### PR TITLE
Fix cve-check-update looping processing META files

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -113,27 +113,19 @@ static cve_string *nvdcve_make_fname(int year, const char *fext)
 
 static char *nvdcve_meta_get_val(FILE *f, const char *field)
 {
-        do {
-                char field_name[256], field_value[256];
-                int ret;
-
-                ret = fscanf(f, " %255[^: \f\n\r\t\v] :%255s", field_name, field_value);
+        char field_name[MAX_META_FILE_KEY_VALUE_SIZE];
+        char field_value[MAX_META_FILE_KEY_VALUE_SIZE];
+        char line[MAX_META_FILE_LINE_SIZE];
+        int ret;
+        while (fgets(line, MAX_META_FILE_LINE_SIZE, f)) {
+                ret = sscanf(line, " %255[^: ] : %255s", field_name, field_value);
                 if (ret != 2) {
-                        if (ret != EOF) {
-                                continue;
-                        }
-                        if (ferror(f)) {
-                                if (errno == EINTR || errno == EAGAIN) {
-                                        clearerr(f);
-                                        continue;
-                                }
-                        }
-                        return NULL;
-                }
-                if (streq(field_name, field)) {
+                        fprintf(stderr, "Ignoring unparseable line in META file\n");
+                } else if (streq(field_name, field)) {
                         return strdup(field_value);
                 }
-        } while (1);
+        }
+        return NULL;
 }
 
 static bool nvdcve_data_ok(const char *meta, const char *data)

--- a/src/update.h
+++ b/src/update.h
@@ -11,6 +11,9 @@
 
 #include "cve-string.h"
 
+#define MAX_META_FILE_LINE_SIZE 512
+#define MAX_META_FILE_KEY_VALUE_SIZE 256
+
 cve_string *get_db_path(const char *path);
 
 int update_required(const char *db_file);


### PR DESCRIPTION
META file should have key:value lines but if the NIST NVD website is
down, instead of the META file, the page describing the site being down
is downloaded instead, which results in cve-check-update getting stuck
in a loop trying to process the invalid META file. This can also be
reproduced easily by tweaking a valid META file to have a colon (:) as
the first character in the file. fscanf fails match, and so doesn't
update the file pointer, and the loop doesn't break if there is no
match unless its EOF.

Fix by using fgets to get lines, and sscanf to parse them to keep file
pointer handling simple.